### PR TITLE
Ensure we migrate subscription types with LegacySync

### DIFF
--- a/database/migrations/2025_07_14_210114_sync_legacy_db_and_backfill_stripe_data.php
+++ b/database/migrations/2025_07_14_210114_sync_legacy_db_and_backfill_stripe_data.php
@@ -15,7 +15,15 @@ return new class extends Migration
 
         LegacySync::syncAll(SyncDirection::LegacyToNew);
 
+        $this->migrateSubscriptionTypes();
+
         $this->backfillStripeProductIds();
+    }
+
+    protected function migrateSubscriptionTypes(): void
+    {
+        DB::table('subscriptions')
+            ->update(['type' => 'default']);
     }
 
     protected function backfillStripeProductIds(): void


### PR DESCRIPTION
This PR adds logic to the LegacySync migration to migrate the `type` column of the `subscriptions` table.

Following successful deployment, migrations must be re-run with `php artisan migrate:fresh`.