### PR TITLE
Fix incorrect page title

### DIFF
--- a/app/Livewire/Settings/Membership.php
+++ b/app/Livewire/Settings/Membership.php
@@ -56,6 +56,6 @@ class Membership extends Component
     public function render(): View
     {
         return view('livewire.settings.membership')
-            ->title(__('navigation.settings.password').' - '.__('settings.title'));
+            ->title(__('navigation.settings.membership').' - '.__('settings.title'));
     }
 }


### PR DESCRIPTION
This fixes the title for the `Settings / Membership` page.