### PR TITLE
Fix 500 error when visiting `membership` page

### DIFF
--- a/resources/views/livewire/settings/membership.blade.php
+++ b/resources/views/livewire/settings/membership.blade.php
@@ -80,7 +80,12 @@
                     <flux:callout icon="information-circle" variant="success">
                         <flux:callout.heading>{{ __('settings.membership.callouts.subscription-active.heading') }}</flux:callout.heading>
                         <flux:callout.text>
-                            {{ __('settings.membership.callouts.subscription-active.text', ['plan' => Membership::fromStripeId($this->subscription->items()->first()->stripe_product)->label()]) }}
+                            {{ __('settings.membership.callouts.subscription-active.text', [
+                                'plan' => ($this->subscription->items->isNotEmpty()
+                                    ? Membership::fromStripeProduct($this->subscription->items->first()->stripe_product)
+                                    : Membership::fromStripePrice($this->subscription->stripe_price)
+                                )->label(),
+                            ]) }}
                         </flux:callout.text>
                     </flux:callout>
                 @elseif($this->subscription->ended())

--- a/tests/Helpers/StripeHelpers.php
+++ b/tests/Helpers/StripeHelpers.php
@@ -36,4 +36,13 @@ class StripeHelpers
             ],
         ];
     }
+
+    public static function stripePriceResponse(string $priceId, string $productId): array
+    {
+        return [
+            'id' => $priceId,
+            'object' => 'price',
+            'product' => $productId,
+        ];
+    }
 }

--- a/tests/Helpers/StripeHelpers.php
+++ b/tests/Helpers/StripeHelpers.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Helpers;
+
+use Mockery;
+use Stripe\ApiRequestor;
+use Stripe\HttpClient\ClientInterface;
+
+class StripeHelpers
+{
+    public static function mockStripeClientWithResponse(array $response, int $times = 1): void
+    {
+        $mock = Mockery::mock(ClientInterface::class);
+
+        $mock->shouldReceive('request')
+            ->times($times)
+            ->andReturn([json_encode($response), 200, []]);
+
+        ApiRequestor::setHttpClient($mock);
+    }
+
+    public static function cleanup(): void
+    {
+        Mockery::close();
+        ApiRequestor::setHttpClient(null);
+    }
+
+    public static function stripeProductResponse(string $priceId): array
+    {
+        return [
+            'id' => 'prod_agepac_123',
+            'object' => 'product',
+            'default_price' => [
+                'id' => $priceId,
+                'object' => 'price',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR aims to resolve #7.

It accepts that some legacy `subscriptions` may not have any `subscription_items` and handles both cases. In this case, it retrieves the membership product from the `stripe_price` associated with the `subscription`.

This is slightly less efficient than retrieving it from the `subscription_item`'s `stripe_product` because it requires a call to the Stripe API in order to resolve the `product_id`. **In the future, we could implement strategic caching to forgo the API call on such a rarely changing resource.**