### PR TITLE
Add caching to some Stripe requests

### DIFF
--- a/app/Actions/RetrieveStripeProductPrice.php
+++ b/app/Actions/RetrieveStripeProductPrice.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Actions;
+
+use Laravel\Cashier\Cashier;
+use Stripe\Price;
+
+class RetrieveStripeProductPrice
+{
+    /**
+     * @throws \Stripe\Exception\ApiErrorException
+     */
+    public function __invoke(string $productId): Price
+    {
+        $stripeProduct = Cashier::stripe()->products->retrieve(
+            $productId,
+            ['expand' => ['default_price']],
+        );
+
+        return $stripeProduct->default_price;
+    }
+}

--- a/app/Enums/Products/Membership.php
+++ b/app/Enums/Products/Membership.php
@@ -64,10 +64,14 @@ enum Membership: string
 
     protected static function getProductFromPrice(string|Price $price): Product|string
     {
-        if (is_string($price)) {
-            $price = Cashier::stripe()->prices->retrieve($price);
+        if ($price instanceof Price) {
+            return $price->product;
         }
 
-        return $price->product;
+        return Cache::remember(
+            "stripe.price.$price.product",
+            now()->addHours(24),
+            fn () => Cashier::stripe()->prices->retrieve($price)->product
+        );
     }
 }

--- a/app/Enums/Products/Membership.php
+++ b/app/Enums/Products/Membership.php
@@ -2,6 +2,7 @@
 
 namespace App\Enums\Products;
 
+use App\Actions\RetrieveStripeProductPrice;
 use App\Exceptions\MembershipNotFoundException;
 use Illuminate\Support\Facades\Cache;
 use Laravel\Cashier\Cashier;
@@ -55,17 +56,9 @@ enum Membership: string
 
     public function stripePrice(): Price
     {
-        return Cache::flexible(
-            "membership.{$this->stripeProductId()}.amount",
-            [300, 600],
-            function () {
-                $stripeProduct = Cashier::stripe()->products->retrieve(
-                    $this->stripeProductId(),
-                    ['expand' => ['default_price']],
-                );
-
-                return $stripeProduct->default_price;
-            },
+        return Cache::rememberForever(
+            "membership.{$this->stripeProductId()}.price",
+            fn () => resolve(RetrieveStripeProductPrice::class)($this->stripeProductId()),
         );
     }
 

--- a/tests/Feature/Actions/RetrieveStripeProductPriceTest.php
+++ b/tests/Feature/Actions/RetrieveStripeProductPriceTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Actions\RetrieveStripeProductPrice;
+use Stripe\Price;
+use Tests\Helpers\StripeHelpers;
+
+afterEach(function () {
+    StripeHelpers::cleanup();
+});
+
+it('retrieves the default price from Stripe product', function () {
+    StripeHelpers::mockStripeClientWithResponse(StripeHelpers::stripeProductResponse('price_123'));
+
+    $action = resolve(RetrieveStripeProductPrice::class);
+
+    expect($action('prod_test_123'))
+        ->toBeInstanceOf(Price::class)
+        ->id->toBe('price_123');
+});

--- a/tests/Feature/Enums/MembershipTest.php
+++ b/tests/Feature/Enums/MembershipTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\Products\Membership;
 use App\Exceptions\MembershipNotFoundException;
+use Illuminate\Support\Facades\Cache;
 use Stripe\Price;
 use Stripe\Product;
 use Tests\Helpers\StripeHelpers;
@@ -98,7 +99,7 @@ it('returns the Stripe price associated with the product', function () {
     expect(Membership::AGEPAC->stripePrice()->id)->toBe('price_123');
 });
 
-it('uses the flexible cache driver to return the Stripe price', function () {
+it('uses cache to return the Stripe price', function () {
     StripeHelpers::mockStripeClientWithResponse(StripeHelpers::stripeProductResponse('price_123'));
 
     // First call: should hit the API
@@ -107,11 +108,12 @@ it('uses the flexible cache driver to return the Stripe price', function () {
     // Change Stripe response after first API request
     StripeHelpers::mockStripeClientWithResponse(StripeHelpers::stripeProductResponse('price_456'));
 
-    // After 5 minutes: Should still hit cache
-    $this->travel(5)->minutes();
+    // Should still hit cache and return the cached value
     expect(Membership::AGEPAC->stripePrice()->id)->toBe('price_123');
 
-    // After 10 minutes: Should have re-fetched from Stripe
-    $this->travel(5)->minutes();
+    // Clear the cache manually to simulate webhook clearing cache
+    Cache::forget('membership.prod_agepac_123.price');
+
+    // Should now fetch the new price from Stripe
     expect(Membership::AGEPAC->stripePrice()->id)->toBe('price_456');
 });


### PR DESCRIPTION
This PR adds caching to some Stripe requests.

## 1. Retrieving a product's default price

In this case, we cache membership product's Price object forever and repopulate the cache when a change is detected using webhooks.

## 2. Retrieving a product from a price

Some older subscriptions don't have related subscription_items. As such, we send the Stripe API a request to retrieve the product from the `price_id` stored on the subscription. The result is then cached for 24 hours.