### PR TITLE
Mirror Cashier-column exclude + invalidate passwords post-incident

### DIFF
--- a/config/legacy_sync.php
+++ b/config/legacy_sync.php
@@ -50,6 +50,16 @@ return [
                 'card_brand' => 'pm_type',
                 'card_last_four' => 'pm_last_four',
             ],
+
+            // Stripe webhooks now land only on this app, so it owns the Cashier-
+            // managed columns. Exclude them in the LegacyToNew direction so a
+            // save on the legacy app can never push a stale Cashier value over a
+            // fresh one squawk just wrote.
+            // Mirrors the same exclude on the legacy app's config/legacy_sync.php.
+            'exclude' => [
+                'legacy' => [],
+                'new' => ['stripe_id', 'pm_type', 'pm_last_four', 'trial_ends_at'],
+            ],
         ],
 
         'subscriptions' => [

--- a/database/migrations/2026_05_31_120000_invalidate_all_passwords.php
+++ b/database/migrations/2026_05_31_120000_invalidate_all_passwords.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Post-incident remediation.
+     *
+     * Mirrors members.agepac.org's invalidation migration. Sentinel value
+     * is the same literal ('RESET_REQUIRED') so legacy_sync — which keeps
+     * the password column in step across both databases via the new
+     * members.UserObserver::updated() handler — sees a no-op when a member
+     * who hasn't yet reset triggers a save.
+     */
+    private const SENTINEL = 'RESET_REQUIRED';
+
+    public function up(): void
+    {
+        DB::table('users')
+            ->whereNotNull('password')
+            ->where('password', '!=', self::SENTINEL)
+            ->update([
+                'password' => self::SENTINEL,
+                'remember_token' => null,
+            ]);
+
+        if (Schema::hasTable('password_reset_tokens')) {
+            DB::table('password_reset_tokens')->truncate();
+        }
+
+        if (Schema::hasTable('sessions')) {
+            DB::table('sessions')->truncate();
+        }
+    }
+
+    public function down(): void
+    {
+        // No-op: invalidated passwords cannot be restored. Roll back by
+        // restoring from a pre-incident database backup.
+    }
+};


### PR DESCRIPTION
## Summary
Two commits, both part of the cross-app post-incident remediation.

### 1. `Exclude Cashier-managed columns from LegacyToNew sync`
This app now receives all Stripe webhooks and owns the Cashier-managed columns on the `users` table (`stripe_id`, `pm_type`, `pm_last_four`, `trial_ends_at`). The legacy app has nothing fresh to push for those columns, but a save there could include them in the `LegacyToNew` sync and overwrite a value this app just wrote. Adding the exclude under `mapping.users` in `config/legacy_sync.php` prevents that race. Mirrors the same block on members' config.

### 2. `Invalidate all passwords post-incident`
The restored database backup contains the same bcrypt hashes that were exfiltrated when the legacy app was compromised. Local login on this app currently redirects to the legacy app, and handoff authenticates by user ID rather than password — so the `password` column here is vestigial. But the hashes themselves are still sensitive and the local `Login` Livewire component could be re-enabled later. Invalidates them as defense-in-depth.

Writes the literal `'RESET_REQUIRED'` into every non-null, non-already-sentinel `users.password`. Same value the legacy app uses, so the `LegacyToNew` sync sees a no-op for any user who hasn't yet gone through the legacy-side reset flow. Also nulls `remember_token`, truncates `password_reset_tokens`, and truncates `sessions`.

`down()` is a documented no-op: invalidated passwords cannot be restored; the only rollback is restoring from a pre-incident backup.

## Test plan
- [x] `php artisan migrate --force` runs cleanly.
- [x] `users.remember_token` is null across the table; `password_reset_tokens` and `sessions` are empty.
- [x] Open the home/dashboard via handoff from members (post-rotation) → confirm normal navigation still works (handoff authenticates by user ID, not password, so it should be unaffected).
- [x] Confirm the existing local Login Livewire route is still a redirect, not the component itself (`routes/auth.php` is unchanged here).

## Pairs with
`sync-user-updates-cross-app` on `members.agepac.org`. Both PRs must ship together — without the matching exclude on this side too, a `NewToLegacy` sync could leak `stripe_id` etc. in the wrong direction.